### PR TITLE
install I2C and Platform for regular Raspbian

### DIFF
--- a/Software/Python/setup.py
+++ b/Software/Python/setup.py
@@ -25,6 +25,6 @@ setuptools.setup(
     description="Drivers and examples for using the PivotPi in Python",
     author="Dexter Industries",
     url="http://www.dexterindustries.com/PivotPi/",
-    py_modules=['pivotpi','PCA9685'],
+    py_modules=['pivotpi','PCA9685', 'I2C', 'Platform'],
     #install_requires=open('requirements.txt').readlines(),
 )


### PR DESCRIPTION
Standalone PivotPi - without Raspbian for Robots - needs those two files to be installed system-wide