### PR TITLE
use quiet_mode

### DIFF
--- a/Install/install.sh
+++ b/Install/install.sh
@@ -114,7 +114,7 @@ fi
 
 popd					 
 
-if [[ "$quiet_mode" -eq 1 ]]
+if quiet_mode
 then
     echo " "
     echo "Installation all done"


### PR DESCRIPTION
Install script still used the old method to detect quiet_mode in order to decide on restart. However quiet_mode was no longer being set the same way, so this test was wrong