### PR TITLE
hotfix / remove input import as not needed and not present on vanilla Raspbian

### DIFF
--- a/Projects/M&Ms_Sorter/PivotPi_BrickPi3_M&Ms_Sorter.py
+++ b/Projects/M&Ms_Sorter/PivotPi_BrickPi3_M&Ms_Sorter.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from __future__ import division
-from builtins import input
 
 import time     # for reference to elapsed time, and for delays
 import colorsys # for RGB to HSV conversion

--- a/Projects/withGrovePi/Elf-on-a-Shelf/elf.py
+++ b/Projects/withGrovePi/Elf-on-a-Shelf/elf.py
@@ -11,7 +11,6 @@ When someone approaches, the Elf will begin enthusiastically waving!  This proje
 
 from __future__ import print_function
 from __future__ import division
-from builtins import input
 
 import time
 

--- a/Software/Python/Control_Panel/pivot_control.py
+++ b/Software/Python/Control_Panel/pivot_control.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from __future__ import division
-from builtins import input
 
 from time import sleep
 from pivotpi import *

--- a/Software/Python/Control_Panel/pivot_control_with_sliders.py
+++ b/Software/Python/Control_Panel/pivot_control_with_sliders.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from __future__ import division
-from builtins import input
 
 
 import subprocess

--- a/Software/Python/example-3_Servos.py
+++ b/Software/Python/example-3_Servos.py
@@ -9,7 +9,6 @@ Copyright (C) 2016 Dexter Industries
 
 from __future__ import print_function
 from __future__ import division
-from builtins import input
 
 
 # In this example we turn three servos on the PivotPi by 90 Degrees, back and forth.  

--- a/Software/Python/example.py
+++ b/Software/Python/example.py
@@ -9,7 +9,6 @@ Copyright (C) 2016 Dexter Industries
 
 from __future__ import print_function
 from __future__ import division
-from builtins import input
 
 
 

--- a/Software/Scratch/PivotPiScratch.py
+++ b/Software/Scratch/PivotPiScratch.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
 from __future__ import division
-from builtins import input
 
 import scratch,sys,threading,math
 import time


### PR DESCRIPTION
Now that we've cleaned up the install, the builtins library is not loaded on a vanilla Raspbian, and we were not using it anyway. 