### PR TITLE
Keep Scratch quiet if no PivotPi is detected

### DIFF
--- a/Software/Scratch/PivotPiScratch.py
+++ b/Software/Scratch/PivotPiScratch.py
@@ -36,7 +36,8 @@ try:
     scratch_pivotpi = pivotpi.PivotPi()
     print("PivotPi is detected.")
 except:
-    print("No PivotPi has been found.")
+    # print("No PivotPi has been found.")
+    pass
 
 def isPivotPiMsg(msg):
     '''


### PR DESCRIPTION
When you start Scratch for any robot, like the BrickPi or the GoPiGo, it will complain that PivotPi is not found. 
I just made it quiet.